### PR TITLE
fix: receiver style

### DIFF
--- a/src/screens/Receiver/index.tsx
+++ b/src/screens/Receiver/index.tsx
@@ -1,10 +1,7 @@
 import { CameraView } from './components/CameraView'
-import styles from './styles.module.css'
 
 export const ReceiverScreen = () => {
   return (
-    <div className={styles.container}>
-      <CameraView />
-    </div>
+    <CameraView />
   )
 }

--- a/src/screens/Receiver/styles.module.css
+++ b/src/screens/Receiver/styles.module.css
@@ -1,3 +1,0 @@
-.container {
-  gap: 1.5rem;
-}


### PR DESCRIPTION
This pull request removes unused styling from the `ReceiverScreen` component. The most important changes include the removal of the `styles.module.css` import and the associated `container` class.

Changes to `ReceiverScreen`:

* [`src/screens/Receiver/index.tsx`](diffhunk://#diff-220e4f2b37e5e8c06294b450279099084fa1270d53e31861ec9753ba2787dc41L2-L8): Removed the `styles.module.css` import and the `container` class from the `ReceiverScreen` component.

Changes to `styles.module.css`:

* [`src/screens/Receiver/styles.module.css`](diffhunk://#diff-939d1c82d16d922ec973b8a095ed0e8f9cb8bfa86e704d13d05739dfc43e3b9cL1-L3): Deleted the `.container` class definition, which is no longer used.