### PR TITLE
feat: QRコード共有URL機能を追加

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -25,7 +25,10 @@
     "qrGeneratorTitle": "QR Code Generator",
     "generatedQRTitle": "Generated QR Code",
     "qrInstructions": "Open xrqr.net on your VR headset and scan this QR code to copy to clipboard",
-    "recreateQR": "Recreate QR"
+    "recreateQR": "Recreate QR",
+    "copyShareLink": "Share this QR code with others",
+    "shareUrlCopied": "Sharing URL copied to clipboard",
+    "shareUrlCopyFailed": "Failed to copy sharing URL"
   },
   "receiver": {
     "qrReaderTitle": "QR Code Reader",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -25,7 +25,10 @@
     "qrGeneratorTitle": "QRコード生成",
     "generatedQRTitle": "生成されたQRコード",
     "qrInstructions": "VRゴーグルで xrqr.net を開いてこのQRコードをスキャンすると、クリップボードにコピーされます",
-    "recreateQR": "QRを作り直す"
+    "recreateQR": "QRを作り直す",
+    "copyShareLink": "このQRコードを他の人と共有",
+    "shareUrlCopied": "共有用のURLをコピーしました",
+    "shareUrlCopyFailed": "共有URLのコピーに失敗しました"
   },
   "receiver": {
     "qrReaderTitle": "QRコードリーダー",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -25,7 +25,10 @@
     "qrGeneratorTitle": "QR 코드 생성기",
     "generatedQRTitle": "생성된 QR 코드",
     "qrInstructions": "VR 헤드셋에서 xrqr.net을 열고 이 QR 코드를 스캔하면 클립보드에 복사됩니다",
-    "recreateQR": "QR 다시 만들기"
+    "recreateQR": "QR 다시 만들기",
+    "copyShareLink": "이 QR 코드를 다른 사람과 공유",
+    "shareUrlCopied": "공유용 URL이 클립보드에 복사되었습니다",
+    "shareUrlCopyFailed": "공유 URL 복사에 실패했습니다"
   },
   "receiver": {
     "qrReaderTitle": "QR 코드 리더",

--- a/src/screens/SenderScreen/components/QRView/index.tsx
+++ b/src/screens/SenderScreen/components/QRView/index.tsx
@@ -1,15 +1,41 @@
 import { useTranslation } from 'react-i18next'
+import { useCallback } from 'react'
 import { Button } from "~/components/Button"
+import { useToastDispatcher } from '~/providers/ToastDispatcher'
 import styles from "./styles.module.css"
 
 interface Props {
   qrCodeUrl: string
+  qrData: string | null
+  isSecure: boolean
   onClickResetQRCode: () => void
 }
 
-export const QRView = ({ qrCodeUrl, onClickResetQRCode }: Props) => {
+export const QRView = ({ qrCodeUrl, qrData, isSecure, onClickResetQRCode }: Props) => {
   const { t } = useTranslation();
-  
+  const { dispatch } = useToastDispatcher()
+
+  const handleCopyShareLink = useCallback(() => {
+    if (!qrData) return
+
+    const encodedData = encodeURIComponent(qrData)
+    const shareUrl = `${window.location.origin}?share=${encodedData}`
+
+    navigator.clipboard.writeText(shareUrl)
+      .then(() => {
+        dispatch({
+          message: t('sender.shareUrlCopied'),
+          type: 'success'
+        })
+      })
+      .catch(() => {
+        dispatch({
+          message: t('sender.shareUrlCopyFailed'),
+          type: 'error'
+        })
+      })
+  }, [qrData, dispatch, t])
+
   return (
     <div className={styles.qrDisplayWrapper}>
       <div className={styles.qrContainer}>
@@ -18,13 +44,24 @@ export const QRView = ({ qrCodeUrl, onClickResetQRCode }: Props) => {
       <div className={styles.qrInstructions}>
         <p>{t('sender.qrInstructions')}</p>
       </div>
-      <Button
-        variant="secondary"
-        size="medium"
-        onClick={onClickResetQRCode}
-      >
-        {t('sender.recreateQR')}
-      </Button>
+      <div className={styles.buttonGroup}>
+        {!isSecure && (
+          <Button
+            variant="primary"
+            size="medium"
+            onClick={handleCopyShareLink}
+          >
+            {t('sender.copyShareLink')}
+          </Button>
+        )}
+        <Button
+          variant="secondary"
+          size="medium"
+          onClick={onClickResetQRCode}
+        >
+          {t('sender.recreateQR')}
+        </Button>
+      </div>
     </div>
   )
 }

--- a/src/screens/SenderScreen/components/QRView/styles.module.css
+++ b/src/screens/SenderScreen/components/QRView/styles.module.css
@@ -26,3 +26,10 @@
   height: auto;
   max-width: 100%;
 }
+
+.buttonGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+}

--- a/src/screens/SenderScreen/index.tsx
+++ b/src/screens/SenderScreen/index.tsx
@@ -1,5 +1,5 @@
 import QRCode from 'qrcode'
-import { useCallback, useState } from 'react'
+import { useCallback, useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FormView } from './components/FormView'
 import { QRView } from './components/QRView'
@@ -10,40 +10,88 @@ import styles from './styles.module.css'
 export const SenderScreen = () => {
   const { t } = useTranslation();
   const [qrCodeUrl, setQrCodeUrl] = useState<string | null>(null)
+  const [qrData, setQrData] = useState<string | null>(null)
+  const [isSecure, setIsSecure] = useState(false)
 
-  const handleSubmit = useCallback(async (content: string, passcode?: string) => {
-    try {
-      const isSecure = !!passcode
-      let processedContent = content
+  // URLパラメータから共有データを取得して自動的にQRコードを生成
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const sharedData = params.get('share')
 
-      // 秘匿情報の場合は暗号化
-      if (isSecure && passcode) {
-        processedContent = encryptText(content, passcode)
+    if (sharedData) {
+      try {
+        const decodedData = decodeURIComponent(sharedData)
+        generateQRFromData(decodedData)
+      } catch (err) {
+        console.error('Failed to decode shared data:', err)
       }
+    }
+  }, [])
 
-      const qrData = JSON.stringify({
-        content: processedContent,
-        isSecret: isSecure,
-        timestamp: new Date().toISOString(),
-        encrypted: isSecure,
-        // パスワードはQRコードに含めない（セキュリティ向上）
-      })
-
-      const qrCode = await QRCode.toDataURL(qrData, {
+  const generateQRFromData = useCallback(async (data: string) => {
+    try {
+      const qrCode = await QRCode.toDataURL(data, {
         errorCorrectionLevel: 'M',
         margin: 2,
         width: 300,
       })
 
+      setQrData(data)
       setQrCodeUrl(qrCode)
+
+      // 共有されたデータから暗号化フラグを取得
+      try {
+        const parsedData = JSON.parse(data)
+        setIsSecure(parsedData.encrypted || false)
+      } catch {
+        setIsSecure(false)
+      }
+    } catch (err) {
+      console.error('QR code generation from shared data failed:', err)
+    }
+  }, [])
+
+  const handleSubmit = useCallback(async (content: string, passcode?: string) => {
+    try {
+      const secure = !!passcode
+      let processedContent = content
+
+      // 秘匿情報の場合は暗号化
+      if (secure && passcode) {
+        processedContent = encryptText(content, passcode)
+      }
+
+      const data = JSON.stringify({
+        content: processedContent,
+        isSecret: secure,
+        timestamp: new Date().toISOString(),
+        encrypted: secure,
+        // パスワードはQRコードに含めない（セキュリティ向上）
+      })
+
+      const qrCode = await QRCode.toDataURL(data, {
+        errorCorrectionLevel: 'M',
+        margin: 2,
+        width: 300,
+      })
+
+      setQrData(data)
+      setQrCodeUrl(qrCode)
+      setIsSecure(secure)
     } catch (err) {
       console.error('QR code generation failed:', err)
     }
-  }, [setQrCodeUrl])
+  }, [])
 
   const handleClickResetQRCode = useCallback(() => {
     setQrCodeUrl(null)
-  }, [setQrCodeUrl])
+    setQrData(null)
+    setIsSecure(false)
+    // URLパラメータをクリア
+    const url = new URL(window.location.href)
+    url.searchParams.delete('share')
+    window.history.replaceState({}, '', url.toString())
+  }, [])
 
   return (
     <Card title={t('sender.qrGeneratorTitle')} className={styles.container}>
@@ -52,6 +100,8 @@ export const SenderScreen = () => {
       ) : (
         <QRView
           qrCodeUrl={qrCodeUrl}
+          qrData={qrData}
+          isSecure={isSecure}
           onClickResetQRCode={handleClickResetQRCode}
         />
       )}


### PR DESCRIPTION
## 概要
生成したQRコードを他の人と共有できるURL機能を実装しました。

## 背景
- MetaQuestなどのHMDで文字入力は困難
- 同じURLを他人と共有したい場合、QRコード自体を共有できると便利
- セキュリティを考慮し、暗号化されたQRコードは共有不可とする

## 変更内容
### 機能追加
- ✨ QRコード生成後に「このQRコードを他の人と共有」ボタンを表示
- 🔗 URLパラメータ `?share=...` でQRコードデータを共有
- 🎯 共有URLにアクセスすると自動的に同じQRコードが表示される
- 🔒 セキュアな共有（暗号化）の場合は共有ボタンを非表示

### 実装詳細
- `SenderScreen`: 共有URL生成・URLパラメータ解析ロジックを追加
- `QRView`: 共有ボタンとトースト通知機能を追加
- 多言語対応: 日本語・英語・韓国語の翻訳を追加

## 動作確認
- [x] QRコード生成後に共有ボタンが表示される
- [x] 共有URLをコピーできる
- [x] 共有URLから正しくQRコードが再生成される
- [x] セキュアな共有の場合、共有ボタンが表示されない
- [x] ビルドが正常に完了する

🤖 Generated with [Claude Code](https://claude.ai/code)